### PR TITLE
0.3.3/world-map

### DIFF
--- a/src/Application/Application.cpp
+++ b/src/Application/Application.cpp
@@ -17,7 +17,7 @@ Application::Application()
     : m_InputHandler(m_Screen, m_PlayerController),
       m_Screen(m_InputHandler, m_WorldManager, m_EntityManager, m_Player),
       m_WorldManager(),
-      m_Player("Gref", 'G' | A_BOLD | COLOR_PAIR(UI::ColorPairs::PlayerEntityIcon)),
+      m_Player("Gref", 'G' | A_BOLD | COLOR_PAIR(UI::ColorPairs::MagentaOnDefault)),
       m_EntityManager(m_WorldManager, m_Player),
       m_PlayerController(m_EntityManager, m_WorldManager, m_Player)
 {

--- a/src/Entities/StaticEntities.cpp
+++ b/src/Entities/StaticEntities.cpp
@@ -6,6 +6,6 @@
 namespace Entities
 {
 
-Entity Wall("Wall", "", ' ' | COLOR_PAIR(UI::ColorPairs::Wall));
+Entity Wall("Wall", "", ' ' | COLOR_PAIR(UI::ColorPairs::BlackOnWhite));
 
 } /* namespace Entities */

--- a/src/UI/ColorPairs.cpp
+++ b/src/UI/ColorPairs.cpp
@@ -1,0 +1,23 @@
+#include "ColorPairs.h"
+#include <ncurses.h>
+
+namespace UI
+{
+
+namespace ColorPairs
+{
+
+void InitPairs()
+{
+    for (short bg = 0; bg < 8; bg++)
+    {
+        for (short fg = 0; fg < 8; fg++)
+        {
+            init_pair(bg * 10 + fg, fg, bg == 0 ? -1 : bg);
+        }
+    }
+}
+
+} /* namespace ColorPairs */
+
+} /* namespace UI */

--- a/src/UI/ColorPairs.cpp
+++ b/src/UI/ColorPairs.cpp
@@ -16,6 +16,7 @@ void InitPairs()
             init_pair(bg * 10 + fg, fg, bg == 0 ? -1 : bg);
         }
     }
+    init_pair(BlackOnDefault, COLOR_BLACK, -1);
 }
 
 } /* namespace ColorPairs */

--- a/src/UI/ColorPairs.h
+++ b/src/UI/ColorPairs.h
@@ -13,6 +13,7 @@ constexpr static const short BlueOnDefault = 4;
 constexpr static const short MagentaOnDefault = 5;
 constexpr static const short CyanOnDefault = 6;
 constexpr static const short WhiteOnDefault = 7;
+constexpr static const short BlackOnDefault = 8;
 
 constexpr static const short BlackOnRed = 10;
 constexpr static const short RedOnRed = 11;

--- a/src/UI/ColorPairs.h
+++ b/src/UI/ColorPairs.h
@@ -6,35 +6,81 @@ namespace UI
 namespace ColorPairs
 {
 
-/**
- * @brief Used for walls
- */
-constexpr const short Wall = 1;
+constexpr static const short RedOnDefault = 1;
+constexpr static const short GreenOnDefault = 2;
+constexpr static const short YellowOnDefault = 3;
+constexpr static const short BlueOnDefault = 4;
+constexpr static const short MagentaOnDefault = 5;
+constexpr static const short CyanOnDefault = 6;
+constexpr static const short WhiteOnDefault = 7;
+
+constexpr static const short BlackOnRed = 10;
+constexpr static const short RedOnRed = 11;
+constexpr static const short GreenOnRed = 12;
+constexpr static const short YellowOnRed = 13;
+constexpr static const short BlueOnRed = 14;
+constexpr static const short MagentaOnRed = 15;
+constexpr static const short CyanOnRed = 16;
+constexpr static const short WhiteOnRed = 17;
+
+constexpr static const short BlackOnGreen = 20;
+constexpr static const short RedOnGreen = 21;
+constexpr static const short GreenOnGreen = 22;
+constexpr static const short YellowOnGreen = 23;
+constexpr static const short BlueOnGreen = 24;
+constexpr static const short MagentaOnGreen = 25;
+constexpr static const short CyanOnGreen = 26;
+constexpr static const short WhiteOnGreen = 27;
+
+constexpr static const short BlackOnYellow = 30;
+constexpr static const short RedOnYellow = 31;
+constexpr static const short GreenOnYellow = 32;
+constexpr static const short YellowOnYellow = 33;
+constexpr static const short BlueOnYellow = 34;
+constexpr static const short MagentaOnYellow = 35;
+constexpr static const short CyanOnYellow = 36;
+constexpr static const short WhiteOnYellow = 37;
+
+constexpr static const short BlackOnBlue = 40;
+constexpr static const short RedOnBlue = 41;
+constexpr static const short GreenOnBlue = 42;
+constexpr static const short YellowOnBlue = 43;
+constexpr static const short BlueOnBlue = 44;
+constexpr static const short MagentaOnBlue = 45;
+constexpr static const short CyanOnBlue = 46;
+constexpr static const short WhiteOnBlue = 47;
+
+constexpr static const short BlackOnMagenta = 50;
+constexpr static const short RedOnMagenta = 51;
+constexpr static const short GreenOnMagenta = 52;
+constexpr static const short YellowOnMagenta = 53;
+constexpr static const short BlueOnMagenta = 54;
+constexpr static const short MagentaOnMagenta = 55;
+constexpr static const short CyanOnMagenta = 56;
+constexpr static const short WhiteOnMagenta = 57;
+
+constexpr static const short BlackOnCyan = 60;
+constexpr static const short RedOnCyan = 61;
+constexpr static const short GreenOnCyan = 62;
+constexpr static const short YellowOnCyan = 63;
+constexpr static const short BlueOnCyan = 64;
+constexpr static const short MagentaOnCyan = 65;
+constexpr static const short CyanOnCyan = 66;
+constexpr static const short WhiteOnCyan = 67;
+
+constexpr static const short BlackOnWhite = 70;
+constexpr static const short RedOnWhite = 71;
+constexpr static const short GreenOnWhite = 72;
+constexpr static const short YellowOnWhite = 73;
+constexpr static const short BlueOnWhite = 74;
+constexpr static const short MagentaOnWhite = 75;
+constexpr static const short CyanOnWhite = 76;
+constexpr static const short WhiteOnWhite = 77;
 
 /**
- * @brief Used for the player entity map icon
+ * @brief Initialize the color pairs
  */
-constexpr const short PlayerEntityIcon = 2;
-
-/**
- * @brief Used for yellow text
- */
-constexpr const short YellowText = 3;
-
-/**
- * @brief Used for accessible fields on the map
- */
-constexpr const short WorldAccessibleField = 4;
-
-/**
- * @brief Used to highlight the field being touched
- */
-constexpr const short WorldTouchedField = 5;
-
-/**
- * @brief Used to highlight the field being touched without a background
- */
-constexpr const short WorldTouchedFieldNoBg = 6;
+void InitPairs();
 
 } /* namespace ColorPairs */
 

--- a/src/UI/InputHandler.cpp
+++ b/src/UI/InputHandler.cpp
@@ -586,7 +586,7 @@ std::string InputHandler::GetTextInputFromPrompt()
 
     // We have to handle the line input ourselves in order to allow the ESC cancel
     curs_set(1);
-    wattron(inputWindow, COLOR_PAIR(ColorPairs::YellowText));
+    wattron(inputWindow, COLOR_PAIR(ColorPairs::YellowOnDefault));
     std::string input;
     input.resize(Screen::ScreenWidth - 25, 0);
     int ch;

--- a/src/UI/InputHandler.cpp
+++ b/src/UI/InputHandler.cpp
@@ -121,7 +121,7 @@ void InputHandler::Eval(const std::string& input)
 
     switch (m_Screen.GetView())
     {
-    case Screen::View::World:
+    case Screen::View::InGame:
         EvalWorld(words);
         break;
     default:
@@ -404,11 +404,11 @@ void InputHandler::HandleNextKeyInput()
         }
         break;
     }
+    case 'm':
+        ExecUICommand(UICommandType::Map);
+        break;
     case 'q':
-        if (m_Screen.YesNoMessageBox("Are you sure you want to quit?"))
-        {
-            SetQuit();
-        }
+        ExecUICommand(UICommandType::Quit);
         break;
     }
 
@@ -478,6 +478,9 @@ void InputHandler::ExecUICommand(UICommandType type)
 {
     switch (type)
     {
+    case UICommandType::Map:
+        m_Screen.ShowMap();
+        break;
     case UICommandType::Quit:
         if (m_Screen.YesNoMessageBox("Are you sure you want to quit?"))
         {

--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -244,13 +244,13 @@ void Screen::Init()
     noecho();
     curs_set(0);
 
-    // Default color pairs
-    init_pair(ColorPairs::Wall, -1, COLOR_WHITE);
-    init_pair(ColorPairs::PlayerEntityIcon, COLOR_MAGENTA, -1);
-    init_pair(ColorPairs::YellowText, COLOR_YELLOW, -1);
-    init_pair(ColorPairs::WorldAccessibleField, COLOR_WHITE, -1);
-    init_pair(ColorPairs::WorldTouchedField, COLOR_RED, COLOR_RED);
-    init_pair(ColorPairs::WorldTouchedFieldNoBg, COLOR_RED, -1);
+    // init_pair(ColorPairs::Wall, -1, COLOR_WHITE);
+    // init_pair(ColorPairs::PlayerEntityIcon, COLOR_MAGENTA, -1);
+    // init_pair(ColorPairs::YellowText, COLOR_YELLOW, -1);
+    // init_pair(ColorPairs::WorldAccessibleField, COLOR_WHITE, -1);
+    // init_pair(ColorPairs::WorldTouchedField, COLOR_RED, COLOR_RED);
+    // init_pair(ColorPairs::WorldTouchedFieldNoBg, COLOR_RED, -1);
+    ColorPairs::InitPairs();
 }
 
 void Screen::Terminate()
@@ -293,7 +293,7 @@ void Screen::DrawLogo(int xPos, int yPos)
     addch('.');
     printw("%d", GameVersionMinor);
     addch('.');
-    attron(COLOR_PAIR(ColorPairs::YellowText));
+    attron(COLOR_PAIR(ColorPairs::YellowOnDefault));
     printw("%d", GameVersionRevision);
     attroff(A_COLOR);
     attroff(A_BOLD);
@@ -520,7 +520,7 @@ void Screen::DrawHUD()
     int xPos = (HUDPanelWidth - wealthAmountStr.size() - 12) / 2;
     xPos += xPos % 2;
     mvwaddstr(m_GameHUDWindow, 14, xPos, "Wealth: ");
-    wattron(m_GameHUDWindow, COLOR_PAIR(ColorPairs::YellowText) | A_BOLD);
+    wattron(m_GameHUDWindow, COLOR_PAIR(ColorPairs::YellowOnDefault) | A_BOLD);
     wprintw(m_GameHUDWindow, "%d", stats.dun);
     wattroff(m_GameHUDWindow, A_COLOR | A_BOLD);
     waddstr(m_GameHUDWindow, " dun");
@@ -602,7 +602,7 @@ void Screen::DrawMap(WINDOW* mapWindow)
             }
             if (m_WorldManager.GetCurrentRoom().GetCoords() == current)
             {
-                icon |= (COLOR_PAIR(ColorPairs::WorldTouchedFieldNoBg) | A_BOLD);
+                icon |= (COLOR_PAIR(ColorPairs::RedOnDefault) | A_BOLD);
             }
             mvwaddch(mapWindow, j + 1, i * 2 + 1, icon);
         }
@@ -624,7 +624,7 @@ chtype Screen::GetFieldIcon(const Worlds::Field& field) const
     }
     else if (field.IsAccessible() && m_CurrentRoom->GetVisionRadius() > 0)
     {
-        icon = '.' | COLOR_PAIR(ColorPairs::WorldAccessibleField);
+        icon = '.' | COLOR_PAIR(ColorPairs::WhiteOnDefault);
         canHaveHighlight = false;
     }
     else
@@ -645,7 +645,7 @@ chtype Screen::GetFieldIcon(const Worlds::Field& field) const
         short bgColorPair = (icon & A_COLOR) >> 8;
         short fg, bg;
         pair_content(bgColorPair, &fg, &bg);
-        highlightPair = (bg > 0) ? ColorPairs::WorldTouchedField : ColorPairs::WorldTouchedFieldNoBg;
+        highlightPair = (bg > 0) ? ColorPairs::RedOnRed : ColorPairs::RedOnDefault;
 
         icon &= ~A_COLOR;
         icon |= COLOR_PAIR(highlightPair) | A_BOLD;

--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -281,6 +281,10 @@ bool Screen::YesNoMessageBox(const std::string& prompt, const std::string& leftO
                 menu_driver(menu, REQ_LEFT_ITEM);
             selectedLeft = !selectedLeft;
             break;
+        // ESC exits with negative response
+        case 27:
+            selectedLeft = false;
+            // drop through
         case KEY_ENTER:
         case 10:
             pressedEnter = true;

--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -712,22 +712,43 @@ chtype Screen::GetRoomMapIcon(const Worlds::Room& room) const
     bool down = room.TryGetEntrance(Direction::Down()) != nullptr;
     bool left = room.TryGetEntrance(Direction::Left()) != nullptr;
 
-    if (up && right && down && left) return ACS_PLUS;
-    if (up && right && down && !left) return ACS_LTEE;
-    if (up && right && !down && left) return ACS_BTEE;
-    if (up && right && !down && !left) return ACS_LLCORNER;
-    if (up && !right && down && left) return ACS_RTEE;
-    if (up && !right && down && !left) return ACS_VLINE;
-    if (up && !right && !down && left) return ACS_LRCORNER;
-    if (up && !right && !down && !left) return ACS_DIAMOND;
-    if (!up && right && down && left) return ACS_TTEE;
-    if (!up && right && down && !left) return ACS_ULCORNER;
-    if (!up && right && !down && left) return ACS_HLINE;
-    if (!up && right && !down && !left) return ACS_DIAMOND;
-    if (!up && !right && down && left) return ACS_URCORNER;
-    if (!up && !right && down && !left) return ACS_DIAMOND;
-    if (!up && !right && !down && left) return ACS_DIAMOND;
-    return 'x';
+    constexpr static const chtype deadEnd = '#';
+
+    if (up)
+    {
+        if (right)
+        {
+            if (down && left) return ACS_PLUS;
+            if (down && !left) return ACS_LTEE;
+            if (!down && left) return ACS_BTEE;
+            if (!down && !left) return ACS_LLCORNER;
+        }
+        else
+        {
+            if (down && left) return ACS_RTEE;
+            if (down && !left) return ACS_VLINE;
+            if (!down && left) return ACS_LRCORNER;
+            if (!down && !left) return deadEnd;
+        }
+    }
+    else
+    {
+        if (right)
+        {
+            if (down && left) return ACS_TTEE;
+            if (down && !left) return ACS_ULCORNER;
+            if (!down && left) return ACS_HLINE;
+            if (!down && !left) return deadEnd;
+        }
+        else
+        {
+            if (down && left) return ACS_URCORNER;
+            if (down && !left) return deadEnd;
+            if (!down && left) return deadEnd;
+        }
+    }
+
+    return deadEnd;
 }
 
 } /* namespace UI */

--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -123,6 +123,9 @@ void Screen::ShowMap()
     WINDOW* mapWindow = newwin(height, width, (ScreenHeight - height) / 2, (ScreenWidth - width) / 2);
     wclear(mapWindow);
     box(mapWindow, 0, 0);
+    wattron(mapWindow, A_REVERSE);
+    PrintCenterAt(mapWindow, " World Map ", 0);
+    wattroff(mapWindow, A_REVERSE);
 
     // Draw the map
     DrawMap(mapWindow);

--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -244,12 +244,6 @@ void Screen::Init()
     noecho();
     curs_set(0);
 
-    // init_pair(ColorPairs::Wall, -1, COLOR_WHITE);
-    // init_pair(ColorPairs::PlayerEntityIcon, COLOR_MAGENTA, -1);
-    // init_pair(ColorPairs::YellowText, COLOR_YELLOW, -1);
-    // init_pair(ColorPairs::WorldAccessibleField, COLOR_WHITE, -1);
-    // init_pair(ColorPairs::WorldTouchedField, COLOR_RED, COLOR_RED);
-    // init_pair(ColorPairs::WorldTouchedFieldNoBg, COLOR_RED, -1);
     ColorPairs::InitPairs();
 }
 
@@ -600,6 +594,8 @@ void Screen::DrawMap(WINDOW* mapWindow)
                 if (room.TryGetEntrance(Direction::Right()) != nullptr)
                     mvwaddch(mapWindow, j + 1, i * 2 + 2, ACS_HLINE);
             }
+
+            // Highlight current room
             if (m_WorldManager.GetCurrentRoom().GetCoords() == current)
             {
                 icon |= (COLOR_PAIR(ColorPairs::RedOnDefault) | A_BOLD);

--- a/src/UI/Screen.h
+++ b/src/UI/Screen.h
@@ -226,11 +226,14 @@ private:
     void DrawMessageWindow();
 
     /**
-     * @brief Draw the map screen
+     * @brief Draw the map in the map window
+     * If cursor coords are set to a non-default value, will draw the cursor
+     * at the specified position.
      * 
      * @param mapWindow map window
+     * @param cursor Cursor position on world grid
      */
-    void DrawMap(WINDOW* mapWindow);
+    void DrawMap(WINDOW* mapWindow, Coords cursor = { -1, -1 });
 
     /**
      * @brief Get the icon for the given field

--- a/src/UI/Screen.h
+++ b/src/UI/Screen.h
@@ -4,6 +4,7 @@
 #include "Entities/Player.h"
 #include "InputHandler.h"
 #include "Misc/Coords.h"
+#include "WorldMapObjectType.h"
 #include "Worlds/Field.h"
 #include "Worlds/Room.h"
 #include <iostream>
@@ -138,6 +139,11 @@ private:
      */
     constexpr static const chtype DefaultFieldIcon = ' ';
 
+    constexpr static const int WorldMapWidth = Worlds::World::MaximumSpan * 2 - 1 + 2;
+    constexpr static const int WorldMapHeight = Worlds::World::MaximumSpan + 2;
+    constexpr static const int WorldMapXPos = (ScreenWidth - WorldMapWidth) / 2;
+    constexpr static const int WorldMapYPos = (ScreenHeight - WorldMapHeight) / 2;
+
     InputHandler& m_InputHandler;
     const Worlds::WorldManager& m_WorldManager;
     const Entities::EntityManager& m_EntityManager;
@@ -148,6 +154,7 @@ private:
     WINDOW* m_GameMessageWindow;
     const Worlds::Room* m_CurrentRoom;
     std::string m_Message;
+    bool m_IsWorldMapCursorEnabled;
 
     /**
      * @brief Initialize the screen
@@ -222,8 +229,10 @@ private:
 
     /**
      * @brief Draw the message window
+     * 
+     * @param shouldPostMessage whether or not to write out the current message
      */
-    void DrawMessageWindow();
+    void DrawMessageWindow(bool shouldPostMessage = true);
 
     /**
      * @brief Draw the map in the map window
@@ -231,9 +240,17 @@ private:
      * at the specified position.
      * 
      * @param mapWindow map window
-     * @param cursor Cursor position on world grid
+     * @param cursor cursor position on world grid
      */
     void DrawMap(WINDOW* mapWindow, Coords cursor = { -1, -1 });
+
+    /**
+     * @brief Draw the tooltip for the object under the cursor
+     * 
+     * @param cursor cursor
+     * @param objectType object type
+     */
+    void DrawMapTooltip(Coords cursor, WorldMapObjectType objectType);
 
     /**
      * @brief Get the icon for the given field
@@ -258,6 +275,14 @@ private:
      * @return chtype map icon
      */
     chtype GetRoomMapIcon(const Worlds::Room& room) const;
+
+    /**
+     * @brief Get the WorldMapObjectType for the given coords
+     * 
+     * @param coords coords
+     * @return WorldMapObjectType object type
+     */
+    WorldMapObjectType GetWorldMapObjectType(Coords coords) const;
 };
 
 } /* namespace UI */

--- a/src/UI/Screen.h
+++ b/src/UI/Screen.h
@@ -32,14 +32,14 @@ public:
         MainMenu,
 
         /**
-         * @brief View of the game world
+         * @brief In game view
          */
-        World,
+        InGame,
 
         /**
-         * @brief View of the player's inventory
+         * @brief World map view
          */
-        Inventory
+        Map
     };
 
     /**
@@ -114,6 +114,11 @@ public:
      * @brief Set the message to display the next time the screen is drawn
      */
     void PostMessage(const std::string& message);
+
+    /**
+     * @brief Show the world map in a window
+     */
+    void ShowMap();
 
     /**
      * @brief Show a centered message box with two menu-like option buttons and a variable prompt
@@ -221,6 +226,13 @@ private:
     void DrawMessageWindow();
 
     /**
+     * @brief Draw the map screen
+     * 
+     * @param mapWindow map window
+     */
+    void DrawMap(WINDOW* mapWindow);
+
+    /**
      * @brief Get the icon for the given field
      * 
      * @param field field
@@ -235,6 +247,14 @@ private:
      * @return chtype icon
      */
     chtype GetFieldIcon(Coords coords) const;
+
+    /**
+     * @brief Get the map icon for this room
+     * 
+     * @param room room
+     * @return chtype map icon
+     */
+    chtype GetRoomMapIcon(const Worlds::Room& room) const;
 };
 
 } /* namespace UI */

--- a/src/UI/WorldMapObjectType.h
+++ b/src/UI/WorldMapObjectType.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace UI
+{
+
+/**
+ * @brief Types of objects visible and selectable on the world map
+ * 
+ */
+enum class WorldMapObjectType
+{
+    /**
+     * @brief Empty
+     */
+    Empty = 0,
+
+    /**
+     * @brief Room
+     */
+    Room,
+
+    /**
+     * @brief Undiscovered room
+     */
+    UndiscoveredRoom
+};
+
+} /* namespace UI */

--- a/src/Worlds/World.cpp
+++ b/src/Worlds/World.cpp
@@ -134,10 +134,7 @@ bool World::RoomExistsAt(Coords coords) const
     if (coords.GetX() >= MaximumSpan || coords.GetY() >= MaximumSpan ||
         coords.GetX() < 0 || coords.GetY() < 0)
     {
-        std::ostringstream errorMessage;
-        errorMessage << "World grid position out of bounds: "
-                     << coords;
-        throw InvalidPositionException(errorMessage.str());
+        return false;
     }
     return m_Rooms[coords.GetX()][coords.GetY()] != nullptr;
 }


### PR DESCRIPTION
Added a World Map to the game.
* The map is accessible via the [m] key or the 'm' and 'map' UI commands
* The map opens in a standalone window and displays all discovered rooms with icons indicating the entrances, as well as all undiscovered rooms accessible from discovered rooms with a question-mark icon
* The map has a cursor which can be moved around the window and snaps to the grid of room icons
* A tooltip displays next to the cursor when hovering over any room, containing information about room (to be expanded in the future)
* If the tooltip doesn't fit on the screen in the default position, it will flip around
* The cursor and tooltip can be toggled on and off with [SPACE]

Additional changes:
* Yes/no message boxes can be closed (choosing "no") with ESC