### PR TITLE
0.3.4: Crossing entrances on the side does not center player in the next room

### DIFF
--- a/src/Entities/EntityManager.cpp
+++ b/src/Entities/EntityManager.cpp
@@ -37,10 +37,12 @@ bool EntityManager::TryMovePlayer(Direction dir)
     {
         Direction nextRoomEntranceDir = dir.Opposite();
         Pluck(m_Player, m_WorldManager.CurrentRoom());
+        Coords offset = m_Player.GetCoords() - m_WorldManager.CurrentRoom().Entrance(dir)->GetCoords();
         Worlds::Room& nextRoom = m_WorldManager.SwitchRoom(dir);
         Coords newCoords = nextRoom
                                .Entrance(nextRoomEntranceDir)
-                               ->GetCoords();
+                               ->GetCoords() +
+                           offset;
         m_Player.SetCoords(newCoords);
         m_Player.SetLastMoveDirection(dir);
         Place(m_Player, nextRoom);


### PR DESCRIPTION
Resolves #13 