### PR TITLE
Bugfix: battle log and game over

### DIFF
--- a/src/UI/BattleScreen.cpp
+++ b/src/UI/BattleScreen.cpp
@@ -550,6 +550,8 @@ void BattleScreen::AnimateBattleEnd()
     }
     werase(tempBottomWindow);
     wrefresh(tempBottomWindow);
+    werase(tempSideWindow);
+    wrefresh(tempSideWindow);
     delwin(tempSideWindow);
     delwin(tempBottomWindow);
 }

--- a/src/UI/Components/LogWindow.cpp
+++ b/src/UI/Components/LogWindow.cpp
@@ -58,13 +58,13 @@ void LogWindow::RefreshContent()
 
 std::vector<std::string> LogWindow::Split(std::string message)
 {
-    const int maxLength = m_Width - 2 - SidePadding * 2;
+    const int maxLength = m_Width - 4 - SidePadding * 2;
     std::vector<std::string> output;
 
     bool first = true;
     while (static_cast<int>(message.size()) > maxLength)
     {
-        int pos = maxLength - 3;
+        int pos = maxLength - 1;
         while (!isspace(message.at(pos)))
         {
             // This will blow up if the message contains a single word longer than the maximum length


### PR DESCRIPTION
* Fixed battle log messages not being split correctly and overdrawing the window border
* Fixed a hanging bit of temporary window left over from the battle end animation on the game over screen