### PR TITLE
Zero damage messaging

### DIFF
--- a/src/UI/BattleScreen.cpp
+++ b/src/UI/BattleScreen.cpp
@@ -175,11 +175,8 @@ void BattleScreen::AnimatePlayerAttack(const Battle::Skill::ApplySkillResult& di
         wrefresh(m_ArenaPanelWindow);
 
         // Log
-        std::ostringstream ossLog;
-        ossLog << m_Battle.GetPlayer().GetName() << (displayData.IsCrit ? " critically hit " : " hit ")
-               << m_Battle.GetEnemy().GetName() << " for " << displayData.Value << " damage!";
-        AppendToLog(ossLog.str());
-
+        LogDamage(displayData, m_Battle.GetPlayer().GetName(), m_Battle.GetEnemy().GetName());
+        
         // Nameplate animations
         m_EnemyNameplate.FlashBorder(ColorPairs::RedOnDefault, 2, animationPeriodMs);
         m_EnemyNameplate.HealthBar.RollBy(-displayData.Value);
@@ -195,10 +192,7 @@ void BattleScreen::AnimatePlayerAttack(const Battle::Skill::ApplySkillResult& di
         wrefresh(m_ArenaPanelWindow);
 
         // Log
-        std::ostringstream ossLog;
-        ossLog << m_Battle.GetPlayer().GetName() << " missed " << m_Battle.GetEnemy().GetName()
-               << " with their attack!";
-        AppendToLog(ossLog.str());
+        LogDamage(displayData, m_Battle.GetPlayer().GetName(), m_Battle.GetEnemy().GetName());
     }
 
     // Wait a bit, delay is shorter if hit due to animations
@@ -258,10 +252,7 @@ void BattleScreen::AnimateEnemyAttack(const Battle::Skill::ApplySkillResult& dis
         wrefresh(m_ArenaPanelWindow);
 
         // Log
-        std::ostringstream ossLog;
-        ossLog << m_Battle.GetEnemy().GetName() << (displayData.IsCrit ? " critically hit " : " hit ")
-               << m_Battle.GetPlayer().GetName() << " for " << displayData.Value << " damage!";
-        AppendToLog(ossLog.str());
+        LogDamage(displayData, m_Battle.GetEnemy().GetName(), m_Battle.GetPlayer().GetName());
 
         // Nameplate animations
         m_PlayerNameplate.FlashBorder(ColorPairs::RedOnDefault, 2, animationPeriodMs);
@@ -278,10 +269,7 @@ void BattleScreen::AnimateEnemyAttack(const Battle::Skill::ApplySkillResult& dis
         wrefresh(m_ArenaPanelWindow);
 
         // Log
-        std::ostringstream ossLog;
-        ossLog << m_Battle.GetEnemy().GetName() << " missed " << m_Battle.GetPlayer().GetName()
-               << " with their attack!";
-        AppendToLog(ossLog.str());
+        LogDamage(displayData, m_Battle.GetEnemy().GetName(), m_Battle.GetPlayer().GetName());
     }
 
     // Wait a bit, delay is shorter if hit due to animations
@@ -554,6 +542,25 @@ void BattleScreen::AnimateBattleEnd()
     wrefresh(tempSideWindow);
     delwin(tempSideWindow);
     delwin(tempBottomWindow);
+}
+
+void BattleScreen::LogDamage(const Battle::Skill::ApplySkillResult& result,
+                             const std::string& attacker,
+                             const std::string& target)
+{
+    if (result.IsHit)
+    {
+        std::ostringstream ossLog;
+        ossLog << attacker << (result.IsCrit ? " critically hit " : " hit ") << target << " for " << result.Value
+               << " damage!";
+        AppendToLog(ossLog.str());
+    }
+    else
+    {
+        std::ostringstream ossLog;
+        ossLog << attacker << " missed " << target << " with their attack!";
+        AppendToLog(ossLog.str());
+    }
 }
 
 } /* namespace UI */

--- a/src/UI/BattleScreen.cpp
+++ b/src/UI/BattleScreen.cpp
@@ -176,10 +176,13 @@ void BattleScreen::AnimatePlayerAttack(const Battle::Skill::ApplySkillResult& di
 
         // Log
         LogDamage(displayData, m_Battle.GetPlayer().GetName(), m_Battle.GetEnemy().GetName());
-        
+
         // Nameplate animations
-        m_EnemyNameplate.FlashBorder(ColorPairs::RedOnDefault, 2, animationPeriodMs);
-        m_EnemyNameplate.HealthBar.RollBy(-displayData.Value);
+        if (displayData.Value > 0)
+        {
+            m_EnemyNameplate.FlashBorder(ColorPairs::RedOnDefault, 2, animationPeriodMs);
+            m_EnemyNameplate.HealthBar.RollBy(-displayData.Value);
+        }
     }
     else
     {
@@ -255,8 +258,11 @@ void BattleScreen::AnimateEnemyAttack(const Battle::Skill::ApplySkillResult& dis
         LogDamage(displayData, m_Battle.GetEnemy().GetName(), m_Battle.GetPlayer().GetName());
 
         // Nameplate animations
-        m_PlayerNameplate.FlashBorder(ColorPairs::RedOnDefault, 2, animationPeriodMs);
-        m_PlayerNameplate.HealthBar.RollBy(-displayData.Value);
+        if (displayData.Value > 0)
+        {
+            m_PlayerNameplate.FlashBorder(ColorPairs::RedOnDefault, 2, animationPeriodMs);
+            m_PlayerNameplate.HealthBar.RollBy(-displayData.Value);
+        }
     }
     else
     {
@@ -548,19 +554,26 @@ void BattleScreen::LogDamage(const Battle::Skill::ApplySkillResult& result,
                              const std::string& attacker,
                              const std::string& target)
 {
+    std::ostringstream ossLog;
+
     if (result.IsHit)
     {
-        std::ostringstream ossLog;
-        ossLog << attacker << (result.IsCrit ? " critically hit " : " hit ") << target << " for " << result.Value
-               << " damage!";
-        AppendToLog(ossLog.str());
+        if (result.Value == 0)
+        {
+            ossLog << attacker << "'s attack did no damage to " << target << "!";
+        }
+        else
+        {
+            ossLog << attacker << (result.IsCrit ? " critically hit " : " hit ") << target << " for " << result.Value
+                   << " damage!";
+        }
     }
     else
     {
-        std::ostringstream ossLog;
         ossLog << attacker << " missed " << target << " with their attack!";
-        AppendToLog(ossLog.str());
     }
+
+    AppendToLog(ossLog.str());
 }
 
 } /* namespace UI */

--- a/src/UI/BattleScreen.h
+++ b/src/UI/BattleScreen.h
@@ -204,6 +204,11 @@ private:
      * @brief Battle end animation
      */
     void AnimateBattleEnd();
+
+    /**
+     * @brief Log damage done in a battle.
+     */
+    void LogDamage(const Battle::Skill::ApplySkillResult& result, const std::string& attacker, const std::string& target);
 };
 
 } /* namespace UI */


### PR DESCRIPTION
Changed damage indications in battle when an attack does no damage. The log message is different and there is no nameplate flash. Includes some refactoring.