### PR TITLE
Allow closing world map with the M key

### DIFF
--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -157,7 +157,7 @@ void Screen::ShowMap()
         }
 
         key = InputHandler::ReadKeypress(
-            { 'w', KEY_UP, 'd', KEY_RIGHT, 's', KEY_DOWN, 'a', KEY_LEFT, ' ', KEY_ENTER, 10, 27, 'q' }, mapWindow);
+            { 'w', KEY_UP, 'd', KEY_RIGHT, 's', KEY_DOWN, 'a', KEY_LEFT, ' ', KEY_ENTER, 10, 27, 'q', 'm' }, mapWindow);
         if (!key)
             continue;
 
@@ -203,6 +203,7 @@ void Screen::ShowMap()
         case 10:
         case 27:
         case 'q':
+        case 'm':
             done = true;
             break;
         }


### PR DESCRIPTION
Every UI (sub)screen should be possible to close with the same key it was opened with. So far the only applicable screen for this change is the world map. When adding new UI elements in the future, keep this in mind to uphold good UX standards.