### PR TITLE
Room discovery

### DIFF
--- a/src/Misc/Coords.h
+++ b/src/Misc/Coords.h
@@ -99,3 +99,13 @@ inline bool operator!=(const Coords& l, const Coords& r)
 }
 
 std::ostream& operator<<(std::ostream& os, const Coords& coords);
+
+template<>
+struct std::hash<Coords>
+{
+    size_t operator()(const Coords& coords) const
+    {
+        std::hash<int32_t> hashFn;
+        return hashFn(coords.X << 16 | coords.Y);
+    }
+};

--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -1188,6 +1188,7 @@ WorldMapObjectType Screen::MapObjectType(Coords coords) const
             const auto& neighbor = world.RoomAt(neighborCoords);
             const auto targetEntrance = neighbor.Entrance(dir.Opposite());
 
+            // Entrance in the neighboring room must exist and be discovered
             if (targetEntrance != nullptr && m_RoomDiscovery.count(&neighbor) > 0
                 && m_RoomDiscovery.at(&neighbor).count(targetEntrance->GetCoords()) > 0
                 && m_RoomDiscovery.at(&neighbor).at(targetEntrance->GetCoords()) == true)

--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -965,7 +965,7 @@ void Screen::DrawMap(WINDOW* mapWindow, Coords cursor)
             case WorldMapObjectType::Room:
             {
                 const auto& room = world.RoomAt(current);
-                icon             = IsRoomFullyDiscovered(room) ? RoomMapIcon(room) : '?';
+                icon             = IsRoomFullyDiscovered(room) ? RoomMapIcon(room) : ('?' | A_REVERSE);
                 if (room.Entrance(Direction::Left) != nullptr
                     && m_RoomDiscovery.at(&room).at(room.Entrance(Direction::Left)->GetCoords()) == true)
                 {
@@ -979,7 +979,7 @@ void Screen::DrawMap(WINDOW* mapWindow, Coords cursor)
                 break;
             }
             case WorldMapObjectType::UndiscoveredRoom:
-                icon = '?';
+                icon = '?' | A_BOLD | COLOR_PAIR(ColorPairs::BlackOnDefault);
                 break;
             }
 
@@ -987,7 +987,8 @@ void Screen::DrawMap(WINDOW* mapWindow, Coords cursor)
             bool isCurrentRoom = m_WorldManager.CurrentRoom().GetCoords() == current;
             if (m_IsWorldMapCursorEnabled && cursor == current)
             {
-                icon |= isCurrentRoom ? (COLOR_PAIR(ColorPairs::BlackOnRed)) : (COLOR_PAIR(ColorPairs::BlackOnYellow));
+                icon |= COLOR_PAIR(ColorPairs::BlackOnYellow);
+                icon &= ~A_REVERSE;
             }
             else if (isCurrentRoom)
             {
@@ -1016,6 +1017,8 @@ void Screen::DrawMapTooltip(Coords cursor, WorldMapObjectType objectType)
         lines.push_back("Room " + std::to_string(room.GetRoomNumber()));
         if (m_WorldManager.IsCurrentRoom(room))
             lines.push_back("* You are here *");
+        if (!IsRoomFullyDiscovered(room))
+            lines.push_back("Partially discovered");
         if (room.GetVisionRadius() > 0)
             lines.push_back("It's dark in " + locPronoun + ".");
         break;

--- a/src/UI/Screen.cpp
+++ b/src/UI/Screen.cpp
@@ -817,9 +817,8 @@ void Screen::DrawWorld()
             {
                 auto radius = m_CurrentRoom->GetVisionRadius();
                 Coords targetCoords(desiredFieldXPos, desiredFieldYPos);
-                if (radius > 0
-                    && playerCoords.Distance(targetCoords)
-                           > (playerCoords.SharesAxis(targetCoords) ? radius - 1 : radius))
+                auto distance = playerCoords.Distance(targetCoords);
+                if (radius > 0 && distance > (playerCoords.SharesAxis(targetCoords) ? radius - 1 : radius))
                 {
                     mvwaddch(m_GameWorldWindow, j, i, DefaultFieldIcon);
                 }
@@ -827,7 +826,8 @@ void Screen::DrawWorld()
                 {
                     // Field is visible
                     // Check if we should add a discovery entry
-                    if (m_RoomDiscovery.at(m_CurrentRoom).count(targetCoords) > 0)
+                    if (m_RoomDiscovery.at(m_CurrentRoom).count(targetCoords) > 0
+                        && (radius == 0 || distance < (playerCoords.SharesAxis(targetCoords) ? radius - 1 : radius)))
                     {
                         m_RoomDiscovery.at(m_CurrentRoom).at(targetCoords) = true;
                     }

--- a/src/UI/Screen.h
+++ b/src/UI/Screen.h
@@ -247,6 +247,7 @@ private:
     std::string m_Message;
     bool m_IsWorldMapCursorEnabled;
     std::unique_ptr<Subscreen> m_Subscreen;
+    std::map<const Worlds::Room*, std::unordered_map<Coords, bool>> m_RoomDiscovery;
 
     /**
      * @brief Initialize the screen
@@ -342,6 +343,14 @@ private:
      * @return WorldMapObjectType object type
      */
     WorldMapObjectType MapObjectType(Coords coords) const;
+
+    /**
+     * @brief Check if the given room is fully discovered (all 4 directions)
+     * 
+     * @param room room to check
+     * @return true if fully discovered, false otherwise
+     */
+    bool IsRoomFullyDiscovered(const Worlds::Room& room) const;
 };
 
 } /* namespace UI */

--- a/src/Worlds/Room.cpp
+++ b/src/Worlds/Room.cpp
@@ -34,7 +34,15 @@ Room::Room(WorldManager& worldManager,
     const auto& entrances = layout.GetEntrances();
     for (const auto& dir : Direction::All)
     {
-        m_Entrances[dir.ToInt()] = entrances.count(dir) > 0 ? &FieldAt(entrances.at(dir)) : nullptr;
+        if (entrances.count(dir) > 0)
+        {
+            m_Entrances[dir.ToInt()] = &FieldAt(entrances.at(dir));
+            m_PointsOfInterest.push_back(entrances.at(dir));
+        }
+        else
+        {
+            m_Entrances[dir.ToInt()] = nullptr;
+        }
     }
 }
 

--- a/src/Worlds/Room.cpp
+++ b/src/Worlds/Room.cpp
@@ -44,6 +44,36 @@ Room::Room(WorldManager& worldManager,
             m_Entrances[dir.ToInt()] = nullptr;
         }
     }
+
+    // If there is only one entrance, add the opposite end of the room as a PoI
+    // to prevent revealing the room icon immediately upon entering
+    if (entrances.size() == 1)
+    {
+        const auto& entrance = *entrances.begin();
+        Coords discoveryPoiCoords;
+        switch (entrance.first())
+        {
+        case Direction::Value::Up:
+            discoveryPoiCoords = { entrance.second.X, static_cast<Coords::Scalar>(m_Height - 1) };
+            break;
+        case Direction::Value::Right:
+            discoveryPoiCoords = { 0, entrance.second.Y };
+            break;
+        case Direction::Value::Down:
+            discoveryPoiCoords = { entrance.second.X, 0 };
+            break;
+        case Direction::Value::Left:
+            discoveryPoiCoords = { static_cast<Coords::Scalar>(m_Width - 1), entrance.second.Y };
+            break;
+        default:
+            return;
+        }
+        while (!FieldAt(discoveryPoiCoords).IsAccessible())
+        {
+            discoveryPoiCoords.Move(entrance.first);
+        }
+        m_PointsOfInterest.push_back(discoveryPoiCoords);
+    }
 }
 
 Coords Room::GetCoords() const

--- a/src/Worlds/Room.h
+++ b/src/Worlds/Room.h
@@ -149,6 +149,13 @@ public:
      */
     double GetNPCSpawnChance() const;
 
+    /**
+     * @brief Get the points of interest
+     * 
+     * @return const std::vector<Coords>& points of interest
+     */
+    inline const std::vector<Coords>& GetPointsOfInterest() const { return m_PointsOfInterest; }
+
 protected:
     WorldManager& m_WorldManager;
     World& m_World;
@@ -162,6 +169,7 @@ protected:
     int m_VisionRadius;
     int m_AccessibleFieldCount;
     double m_NPCSpawnChance;
+    std::vector<Coords> m_PointsOfInterest;
 };
 
 } /* namespace Worlds */


### PR DESCRIPTION
Introduced a room discovery mechanic. Previously, upon entering a room its world map icon would immediately be revealed, giving the player information about the room's contents and entrances or lack thereof, even if the player hasn't actually seen any of it in the room.
This adds the concept of "points of interest" to each room, which as of now shall include all entrances and, if there is only one entrance, an arbitrary point on the other side of the room. Until all PoIs have been seen by the player in a room (accounting for vision radius or limited visibility range due to player-centered camera), the room's world map icon will be hidden and an indication of incomplete exploration added to the tooltip.

Example of world map indication:
![image](https://user-images.githubusercontent.com/25676174/104014393-3c718300-51b3-11eb-85e6-1d31061f0e49.png)
![image](https://user-images.githubusercontent.com/25676174/104014845-fff25700-51b3-11eb-8c7f-25a91ca47f62.png)

